### PR TITLE
feature/login-cha

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// jjwt
+	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/smu_club/SmuClubApplication.java
+++ b/backend/src/main/java/com/example/smu_club/SmuClubApplication.java
@@ -2,7 +2,9 @@ package com.example.smu_club;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SmuClubApplication {
 

--- a/backend/src/main/java/com/example/smu_club/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/smu_club/auth/controller/AuthController.java
@@ -1,0 +1,73 @@
+package com.example.smu_club.auth.controller;
+
+
+import com.example.smu_club.auth.dto.JwtTokenResponse;
+import com.example.smu_club.auth.dto.LoginRequest;
+import com.example.smu_club.auth.dto.ReissueRequest;
+import com.example.smu_club.auth.dto.SignupRequest;
+import com.example.smu_club.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.security.auth.login.LoginException;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/public/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<JwtTokenResponse> login(@RequestBody LoginRequest loginRequest) {
+        log.info("사용자 로그인 시도 :{}", loginRequest.getStudentId());
+
+        try {
+            JwtTokenResponse jwtTokenResponse = authService.login(loginRequest);
+            return ResponseEntity.ok(jwtTokenResponse);
+        } catch (LoginException e) {
+            log.warn("로그인 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<JwtTokenResponse> reissue(@RequestBody ReissueRequest reissueRequest) {
+        try {
+            // 성공했을 경우의 로직
+            JwtTokenResponse jwtTokenResponse = authService.reissueTokens(reissueRequest);
+            return ResponseEntity.ok(jwtTokenResponse);
+
+        } catch (LoginException e) {
+            log.warn("refresh Token 검증 실패");
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .build();
+        }
+    }
+
+    @PostMapping("signup")
+    public ResponseEntity<JwtTokenResponse> signup(@RequestBody SignupRequest signupRequest) {
+        log.info("신규 사용자 회원가입 시도 :{}", signupRequest.getStudentId());
+        try {
+            JwtTokenResponse jwtTokenResponse = authService.signup(signupRequest);
+            return ResponseEntity.status(HttpStatus.CREATED).body(jwtTokenResponse);
+        } catch (LoginException e) {
+            // 학교 API 인증 실패
+            log.warn("학교 API 인증 실패 : {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        } catch (IllegalStateException e) {
+            // 이미 가입된 회원인 경우
+            log.warn("이미 가입된 사용자: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+    }
+
+}

--- a/backend/src/main/java/com/example/smu_club/auth/dto/JwtTokenResponse.java
+++ b/backend/src/main/java/com/example/smu_club/auth/dto/JwtTokenResponse.java
@@ -1,0 +1,16 @@
+package com.example.smu_club.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class JwtTokenResponse {
+
+    private String grantType; // "Bearer"
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/example/smu_club/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/example/smu_club/auth/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.example.smu_club.auth.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+
+    private String studentId;
+    private String password;
+}

--- a/backend/src/main/java/com/example/smu_club/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/example/smu_club/auth/dto/LoginResponse.java
@@ -1,0 +1,16 @@
+package com.example.smu_club.auth.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL) // json 변환시 null필드 제외
+public class LoginResponse {
+
+    private String status;
+    private String studentId;
+    private String name;
+}

--- a/backend/src/main/java/com/example/smu_club/auth/dto/ReissueRequest.java
+++ b/backend/src/main/java/com/example/smu_club/auth/dto/ReissueRequest.java
@@ -1,0 +1,10 @@
+package com.example.smu_club.auth.dto;
+
+
+import lombok.Getter;
+
+@Getter
+public class ReissueRequest {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/example/smu_club/auth/dto/SignupRequest.java
+++ b/backend/src/main/java/com/example/smu_club/auth/dto/SignupRequest.java
@@ -1,0 +1,13 @@
+package com.example.smu_club.auth.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+
+    private String studentId;
+    private String password;
+}

--- a/backend/src/main/java/com/example/smu_club/auth/dto/UnivAuthRequest.java
+++ b/backend/src/main/java/com/example/smu_club/auth/dto/UnivAuthRequest.java
@@ -1,0 +1,11 @@
+package com.example.smu_club.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UnivAuthRequest {
+    private String username;
+    private String password;
+}

--- a/backend/src/main/java/com/example/smu_club/auth/dto/UnivUserInfoResponse.java
+++ b/backend/src/main/java/com/example/smu_club/auth/dto/UnivUserInfoResponse.java
@@ -1,0 +1,14 @@
+package com.example.smu_club.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UnivUserInfoResponse {
+    private String username;
+    private String name;
+    private String email;
+    private String department;
+    private String secondDepartment;
+}

--- a/backend/src/main/java/com/example/smu_club/auth/external/UnivApiClient.java
+++ b/backend/src/main/java/com/example/smu_club/auth/external/UnivApiClient.java
@@ -1,0 +1,9 @@
+package com.example.smu_club.auth.external;
+
+import com.example.smu_club.auth.dto.UnivUserInfoResponse;
+import reactor.core.publisher.Mono;
+
+public interface UnivApiClient {
+
+    UnivUserInfoResponse authenticate(String studentId, String password);
+}

--- a/backend/src/main/java/com/example/smu_club/auth/external/UnivApiClientImpl.java
+++ b/backend/src/main/java/com/example/smu_club/auth/external/UnivApiClientImpl.java
@@ -1,0 +1,36 @@
+package com.example.smu_club.auth.external;
+
+
+import com.example.smu_club.auth.dto.UnivAuthRequest;
+import com.example.smu_club.auth.dto.UnivUserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UnivApiClientImpl implements UnivApiClient {
+
+    private final RestClient restClient;
+
+    @Override
+    public UnivUserInfoResponse authenticate(String studentId, String password) {
+
+        UnivAuthRequest requestPayload = new UnivAuthRequest(studentId, password);
+
+        try {
+            return restClient.post()
+                    .uri("/auth")
+                    .body(requestPayload)
+                    .retrieve()
+                    .body(UnivUserInfoResponse.class);
+        } catch (RestClientResponseException e) {
+            log.warn("학교 인증 실패, 학번: {}, 상태코드: {}", studentId, e.getStatusCode());
+
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/smu_club/auth/repository/MemberRepository.java
+++ b/backend/src/main/java/com/example/smu_club/auth/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.example.smu_club.auth.repository;
+
+import com.example.smu_club.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByStudentId(String studentId);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
+}

--- a/backend/src/main/java/com/example/smu_club/auth/token/JwtTokenProvider.java
+++ b/backend/src/main/java/com/example/smu_club/auth/token/JwtTokenProvider.java
@@ -1,0 +1,133 @@
+    package com.example.smu_club.auth.token;
+
+
+    import com.example.smu_club.auth.dto.JwtTokenResponse;
+    import com.example.smu_club.domain.Member;
+    import io.jsonwebtoken.*;
+    import io.jsonwebtoken.io.Decoders;
+    import io.jsonwebtoken.security.Keys;
+    import lombok.extern.slf4j.Slf4j;
+    import org.springframework.beans.factory.annotation.Value;
+    import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+    import org.springframework.security.core.Authentication;
+    import org.springframework.security.core.GrantedAuthority;
+    import org.springframework.security.core.authority.SimpleGrantedAuthority;
+    import org.springframework.security.core.userdetails.User;
+    import org.springframework.security.core.userdetails.UserDetails;
+    import org.springframework.stereotype.Component;
+
+    import java.security.Key;
+    import java.util.Collection;
+    import java.util.Collections;
+    import java.util.Date;
+    import java.util.UUID;
+
+    @Slf4j
+    @Component
+    public class JwtTokenProvider {
+
+        private static final String AUTHORITIES = "auth";
+        private final Key key;
+        private final long accessTokenValidityInMilliseconds;
+        private final long refreshTokenValidityInMilliseconds;
+
+        public JwtTokenProvider(@Value("${jwt.secret}") String secretKey,
+                                @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInSeconds,
+                                @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds) {
+            byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+            this.key = Keys.hmacShaKeyFor(keyBytes);
+            this.accessTokenValidityInMilliseconds = accessTokenValidityInSeconds * 1000;
+            this.refreshTokenValidityInMilliseconds = refreshTokenValidityInSeconds * 1000;
+        }
+
+
+        /*public String generateToken(Authentication authentication) {
+            String authorities = authentication.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.joining(","));
+
+            long now = (new Date()).getTime();
+            Date accessTokenExpiresIn = new Date(now + accessTokenValidityInMilliseconds);
+
+            return Jwts.builder()
+                    .setSubject(authentication.getName())
+                    .claim(AUTHORITIES, authorities)
+                    .setIssuedAt(new Date(now))
+                    .setExpiration(accessTokenExpiresIn)
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+        }*/
+
+        public JwtTokenResponse generateToken(Member member) {
+            String authorities = member.getRole().getKey();
+
+            long now = (new Date()).getTime();
+
+            // access Token 생성
+            Date accessTokenExpiresIn = new Date(now + accessTokenValidityInMilliseconds);
+
+            String accessToken = Jwts.builder()
+                    .setSubject(member.getStudentId())
+                    .claim(AUTHORITIES, authorities)
+                    .setIssuedAt(new Date(now))
+                    .setExpiration(accessTokenExpiresIn)
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+
+
+            // refreshToken 생성
+            Date refreshTokenExpiresIn = new Date(now + refreshTokenValidityInMilliseconds);
+            String refreshToken = Jwts.builder()
+                    .setExpiration(refreshTokenExpiresIn)
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+
+            return JwtTokenResponse.builder()
+                    .grantType("Bearer")
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+        }
+
+        public boolean validateToken(String token) {
+            try {
+                Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+                return true;
+            } catch (SecurityException | MalformedJwtException e) {
+                log.info("잘못된 JWT 서명입니다.");
+            } catch (ExpiredJwtException e) {
+                log.info("만료된 JWT 토큰입니다.");
+            } catch (UnsupportedJwtException e) {
+                log.info("지원되지 않는 JWT 토큰입니다.");
+            } catch (IllegalArgumentException e) {
+                log.info("JWT 토큰이 잘못되었습니다.");
+            }
+            return false;
+        }
+
+
+        public Authentication getAuthentication(String accessToken) {
+
+            Claims claims = parseClaims(accessToken);
+
+            if(claims.get(AUTHORITIES) == null) {
+                throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+            }
+
+            Collection<? extends GrantedAuthority> authorities =
+                    Collections.singletonList(new SimpleGrantedAuthority(claims.get(AUTHORITIES).toString()));
+
+            UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+            return new UsernamePasswordAuthenticationToken(principal,"", authorities);
+        }
+
+        // Key로 토큰 검증
+        private Claims parseClaims(String accessToken) {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        }
+    }

--- a/backend/src/main/java/com/example/smu_club/config/AppConfig.java
+++ b/backend/src/main/java/com/example/smu_club/config/AppConfig.java
@@ -1,0 +1,22 @@
+package com.example.smu_club.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+
+@Configuration
+public class AppConfig {
+
+    @Value("${external.univ-api.url}")
+    private String univApiUrl;
+
+    @Bean
+    public RestClient univRestClient() {
+        return RestClient.builder()
+                .baseUrl(univApiUrl)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/smu_club/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/smu_club/config/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.example.smu_club.config;
+
+import com.example.smu_club.auth.token.JwtTokenProvider;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final  String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String jwt = resolveToken(request);
+
+        if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+
+
+
+
+}

--- a/backend/src/main/java/com/example/smu_club/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/smu_club/config/SecurityConfig.java
@@ -1,0 +1,65 @@
+package com.example.smu_club.config;
+
+
+import com.example.smu_club.auth.token.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 역할 계층 설정
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        String hierarchy = "ROLE_ADMIN > ROLE_OWNER\n" +
+                        "ROLE_OWNER > ROLE_MEMBER";
+
+        return RoleHierarchyImpl.fromHierarchy(hierarchy);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                // 세션 사용 안함 - JWT 사용
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/public/**", "/api/v1/auth/status").permitAll()
+
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/owner/**").hasRole("OWNER")
+                        .requestMatchers("/api/v1/member/**").hasRole("MEMBER")
+
+                        .anyRequest().authenticated()
+                )
+
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/backend/src/main/java/com/example/smu_club/domain/Member.java
+++ b/backend/src/main/java/com/example/smu_club/domain/Member.java
@@ -25,12 +25,17 @@ public class Member {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)
     private String department;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        this.createdAt = (this.createdAt == null) ? LocalDateTime.now() : this.createdAt;
+    }
 }

--- a/backend/src/main/java/com/example/smu_club/domain/Member.java
+++ b/backend/src/main/java/com/example/smu_club/domain/Member.java
@@ -1,17 +1,23 @@
 package com.example.smu_club.domain;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import org.hibernate.annotations.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.*;
+import java.util.Collection;
+import java.util.List;
 
 @Entity
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class Member {
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Member implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,11 +37,63 @@ public class Member {
     @Column(nullable = false)
     private String department;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @PrePersist
-    void onCreate() {
-        this.createdAt = (this.createdAt == null) ? LocalDateTime.now() : this.createdAt;
+    @Column(length = 255)
+    private String refreshToken;
+
+    @Builder
+    public Member(String studentId, String name, String email, String department, Role role) {
+        this.studentId = studentId;
+        this.name = name;
+        this.email = email;
+        this.department = department;
+        this.role = role;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(this.role.getKey()));
+    }
+
+    @Override
+    public String getUsername() {
+        return this.studentId;
+    }
+
+    // 우리 시스템에서는 Password에 대해서 다루지 않기 때문에 null을 반환한다.
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/backend/src/main/java/com/example/smu_club/domain/Role.java
+++ b/backend/src/main/java/com/example/smu_club/domain/Role.java
@@ -1,0 +1,21 @@
+package com.example.smu_club.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    MEMBER("ROLE_MEMBER", "일반 회원"),
+    OWNER("ROLE_OWNER", "클럽장"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    // 위에서 만든 생성자를 만들어주는 역할
+    private final String key;
+    private final String title;
+
+
+
+
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,3 +15,12 @@ spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
 # --- Logging
 logging.level.org.hibernate.SQL=debug
 logging.level.org.hibernate.orm.jdbc.bind=trace
+
+# --- JWT
+jwt.secret=${JWT_SECRET}
+jwt.access-token-validity-in-seconds=1800 
+jwt.refresh-token-validity-in-seconds:604800
+
+# --- ?? auth API
+external.univ-api.url=https://smunity.co.kr/api/v1
+


### PR DESCRIPTION
로그인 및 토큰 발급

로그인 성공 시, 사용자에게 Access Token을 즉시 발급합니다.

동시에 새로운 Refresh Token을 생성하여 데이터베이스에 저장/업데이트합니다. 이는 토큰 탈취 시 보안을 강화하기 위함입니다.

Access Token 재발급 로직

Access Token이 만료되었을 경우, 요청에 포함된 Refresh Token의 유효성을 검증합니다.

Refresh Token이 유효하다면, 새로운 Access Token을 재발급하여 사용자가 재로그인 없이 서비스를 계속 이용할 수 있도록 처리합니다.

신규 사용자 처리 정책

학교 외부 API를 통한 인증에 성공했더라도, 서비스 자체 DB에 사용자 정보가 없는 경우 임시로 예외(Exception)를 발생시키도록 처리했습니다.

(논의 필요) 이 정책은 추후 기획에 따라 '온보딩(회원가입) 페이지로 리디렉션' 또는 '정상 응답(200 OK) 후 추가 정보 입력 유도' 등으로 변경될 수 있습니다.